### PR TITLE
Change Discovery Definition from HomeMonitoring to SharedCarePlanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The following presentation definition is needed:
 # Service Discovery definition
 
 - Development environment: TODO
-- Test environment: see `config/nuts/discovery/test:HomeMonitoring2024.json`
+- Test environment: see `config/nuts/discovery/test:SharedCarePlanning2024.json`
 - Acceptance environment: TODO
 - Production environment: TODO
 

--- a/config/nuts/discovery/test:SharedCarePlanning2024.json
+++ b/config/nuts/discovery/test:SharedCarePlanning2024.json
@@ -1,9 +1,9 @@
 {
-  "id": "test:HomeMonitoring2024",
-  "endpoint": "https://zorgbijjou.test.integration.zorgbijjou.com/nuts/discovery/dev:HomeMonitoring2024",
+  "id": "test:SharedCarePlanning2024",
+  "endpoint": "https://zorgbijjou.test.integration.zorgbijjou.com/nuts/discovery/dev:SharedCarePlanning2024",
   "presentation_max_validity": 2764800,
   "presentation_definition": {
-    "id": "test:HomeMonitoring2024",
+    "id": "test:SharedCarePlanning2024",
     "format": {
       "ldp_vc": {
         "proof_type": [

--- a/config/nuts/discovery/test:SharedCarePlanning2024.json
+++ b/config/nuts/discovery/test:SharedCarePlanning2024.json
@@ -1,6 +1,6 @@
 {
   "id": "test:SharedCarePlanning2024",
-  "endpoint": "https://zorgbijjou.test.integration.zorgbijjou.com/nuts/discovery/dev:SharedCarePlanning2024",
+  "endpoint": "https://zorgbijjou.test.integration.zorgbijjou.com/nuts/discovery/test:SharedCarePlanning2024",
   "presentation_max_validity": 2764800,
   "presentation_definition": {
     "id": "test:SharedCarePlanning2024",


### PR DESCRIPTION
> The reason of having the Home montoring Discovery Service was to have a way of finding parties that offer it (Zorg bij jou). But this fact (URA number of the Task filler, the organization that provides Home monitoring in this case) is already provided by the EHR in the Service Request, so we don't need an additional service for looking up organization that provide it. And secondly, there will be only 1 for now (Zorg bij jou), so we don't need to have it configurable.